### PR TITLE
fix: Resolve issue with updating user refresh token in the database

### DIFF
--- a/src/main/java/login/oauthtest4/global/jwt/service/JwtService.java
+++ b/src/main/java/login/oauthtest4/global/jwt/service/JwtService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.transaction.Transactional;
 import java.util.Date;
 import java.util.Optional;
 
@@ -18,6 +19,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Getter
 @Slf4j
+@Transactional
 public class JwtService {
 
     @Value("${jwt.secretKey}")


### PR DESCRIPTION
안녕하세요! 정리해주신 코드 보고 많은 공부가 되었습니다 감사합니다

작성해주신 코드에 대해 공부하던 중 OAuth 로그인 후 DB에 User refresh token이 업데이트 되지 않음을 확인했습니다

LoginSuccessHandler 클래스의 loginSuccess 메서드를 보면 jwtService.updateRefreshToken를 통해 유저의 RefreshToken을 업데이트 하려고 하는 코드를 보았습니다

현재는 DB에 반영되지 않고 있어 DB에 반영하는 코드를 작성해봤습니다

항상 ID/PW 로그인과 OAuth 로그인을 공부하는 데 있어 이 둘을 통합하려면 어떻게 해야할까 고민을 많이 했는데 이렇게 정리해주셔서 감사합니다

좋은 하루 되세요